### PR TITLE
クローラーがCloudflareの内部ページをインデックスしないよう設定

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
 Disallow: /assets/
 Disallow: /icons/
+Disallow: /cdn-cgi/


### PR DESCRIPTION
GoogleのクローラーがCloudflare Pagesのボットファイトモードで扱われるページをインデックスしようとして404エラーになっているため対象のパスをクロールしないよう設定

https://developers.cloudflare.com/support/other-languages/%E6%97%A5%E6%9C%AC%E8%AA%9E/%E3%82%AF%E3%83%AD%E3%83%BC%E3%83%AB%E3%82%A8%E3%83%A9%E3%83%BC%E3%81%AE%E3%83%88%E3%83%A9%E3%83%96%E3%83%AB%E3%82%B7%E3%83%A5%E3%83%BC%E3%83%86%E3%82%A3%E3%83%B3%E3%82%B0/#%e3%82%af%e3%83%ad%e3%83%bc%e3%83%ab-%e3%82%a8%e3%83%a9%e3%83%bc%e3%82%92%e5%9b%9e%e9%81%bf%e3%81%99%e3%82%8b